### PR TITLE
Accessibility update tooltip.js tests

### DIFF
--- a/js/tests/unit/tooltip.js
+++ b/js/tests/unit/tooltip.js
@@ -57,6 +57,18 @@ $(function () {
     var $trigger = $('<a href="#" rel="tooltip" title="Another tooltip"/>').bootstrapTooltip()
     assert.strictEqual($trigger.attr('title'), '', 'title attribute was emptied')
   })
+  
+  QUnit.test('should add aria-label attribute for referencing original title', function (assert) {
+    assert.expect(1)
+    var $trigger = $('<a href="#" rel="tooltip" title="Another tooltip"/>').bootstrapTooltip()
+    assert.strictEqual($trigger.attr('aria-label'), 'Another tooltip', 'original title preserved in aria-label attribute')
+  })
+  
+  QUnit.test('aria-label attribute not added if the attribute already exists', function (assert) {
+    assert.expect(1)
+    var $trigger = $('<a href="#" rel="tooltip" aria-label="Different label" title="Another tooltip"/>').bootstrapTooltip()
+    assert.strictEqual($trigger.attr('aria-label'), 'Different label', 'original aria-label preserved')
+  })
 
   QUnit.test('should add data attribute for referencing original title', function (assert) {
     assert.expect(1)


### PR DESCRIPTION
Update to the tooltip.js to add an aria-label attribute that contains the original title of the element, but only if the element doesn't have an existing aria-label attribute.

This is to address cases where screen readers are not capturing the aria-describedby attribute that is added when the tooltip is triggered.  This should also avoid a race condition between the screen reader and the appearance of the tooltip.

In the case the aria-describedby is added as intended, it overrides the aria-label, so there should be no collision between the two labels.